### PR TITLE
Swiching to python 3.10 for building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Build database
         run: |
           pip install pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,7 @@ doc_build = [
   "ipykernel",
   "jupyter",
   "nbconvert",
-  "notedown",
-  "setuptools"
+  "notedown"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Swiching to python 3.10 for building docs in CI due to issues with notedown